### PR TITLE
Correct example for icon based checklist.

### DIFF
--- a/docs/_includes/checklist.adoc
+++ b/docs/_includes/checklist.adoc
@@ -43,7 +43,6 @@ include::ex-ulist.adoc[tag=check-int]
 As a bonus, if you enable font-based icons, the checkbox markup (in non-interactive lists) is transformed into a font-based icon!
 
 .Checklist with font-based checkboxes
-[source]
-----
+====
 include::ex-ulist.adoc[tag=check-icon]
-----
+====

--- a/docs/_includes/ex-ulist.adoc
+++ b/docs/_includes/ex-ulist.adoc
@@ -77,7 +77,6 @@ Included in:
 // end::check-int[]
 
 // tag::check-icon[]
-[%interactive]
 * [*] checked
 * [x] also checked
 * [ ] not checked


### PR DESCRIPTION
1. As the example is for non-interactive, remove the interactive role,
2. Show the rendered result instead of the source.